### PR TITLE
Struct Components using `Ref<T>`

### DIFF
--- a/RelEcs.csproj
+++ b/RelEcs.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>default</LangVersion>
+    <LangVersion>10</LangVersion>
     <TargetFramework>netstandard2.1</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>A lightweight and easy to use entity component system with an effective feature set for making games.</Description>

--- a/src/Archetypes.cs
+++ b/src/Archetypes.cs
@@ -46,7 +46,8 @@ namespace RelEcs
 
             var entity = new Entity(identity);
 
-            table.Storages[0].SetValue(entity, row);
+            var entityStorage = (Entity[])table.Storages[0];
+            entityStorage[row] = entity;
 
             return entity;
         }
@@ -136,12 +137,13 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public object GetComponent(StorageType type, Identity identity)
+        public ref T GetComponent<T>(Identity identity, Identity target)
         {
+            var type = StorageType.Create<T>(target);
             var meta = Meta[identity.Id];
             var table = Tables[meta.TableId];
-            var storage = table.GetStorage(type);
-            return storage.GetValue(meta.Row);
+            var storage = (T[])table.GetStorage(type);
+            return ref storage[meta.Row];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Entity.cs
+++ b/src/Entity.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace RelEcs
 {
-    public class Entity
+    public readonly struct Entity
     {
         public static readonly Entity None = new(Identity.None);
         public static readonly Entity Any = new(Identity.Any);
@@ -37,11 +37,10 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator ==(Entity left, Entity right) => left is not null && left.Equals(right);
+        public static bool operator ==(Entity left, Entity right) => left.Equals(right);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool operator !=(Entity left, Entity right) =>
-            (left is null && right is not null) || (left is not null && !left.Equals(right));
+        public static bool operator !=(Entity left, Entity right) => !left.Equals(right);
     }
 
     public readonly struct EntityBuilder
@@ -57,14 +56,14 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityBuilder Add<T>(Entity target = default) where T : class
+        public EntityBuilder Add<T>(Entity target = default) where T : struct
         {
-            World.AddComponent<T>(_entity, target ?? Entity.None);
+            World.AddComponent<T>(_entity, target);
             return this;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityBuilder Add<T>(Type type) where T : class
+        public EntityBuilder Add<T>(Type type) where T : struct
         {
             var typeEntity = World.GetTypeEntity(type);
             World.AddComponent<T>(_entity, typeEntity);
@@ -72,21 +71,21 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityBuilder Add<T>(T data) where T : class
+        public EntityBuilder Add<T>(T data) where T : struct
         {
             World.AddComponent(_entity, data);
             return this;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityBuilder Add<T>(T data, Entity target) where T : class
+        public EntityBuilder Add<T>(T data, Entity target) where T : struct
         {
             World.AddComponent(_entity, data, target);
             return this;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityBuilder Add<T>(T data, Type type) where T : class
+        public EntityBuilder Add<T>(T data, Type type) where T : struct
         {
             var typeEntity = World.GetTypeEntity(type);
             World.AddComponent(_entity, data, typeEntity);
@@ -94,21 +93,21 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityBuilder Remove<T>() where T : class
+        public EntityBuilder Remove<T>() where T : struct
         {
             World.RemoveComponent<T>(_entity);
             return this;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityBuilder Remove<T>(Entity target) where T : class
+        public EntityBuilder Remove<T>(Entity target) where T : struct
         {
             World.RemoveComponent<T>(_entity, target);
             return this;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public EntityBuilder Remove<T>(Type type) where T : class
+        public EntityBuilder Remove<T>(Type type) where T : struct
         {
             var typeEntity = World.GetTypeEntity(type);
             World.RemoveComponent<T>(_entity, typeEntity);

--- a/src/Query.cs
+++ b/src/Query.cs
@@ -58,11 +58,12 @@ namespace RelEcs
     }
 
     public class TriggerQuery<C> : Query
-        where C : class
+        where C : struct
     {
         readonly Type _systemType;
 
-        public TriggerQuery(Archetypes archetypes, Mask mask, List<Table> tables, Type systemType) : base(archetypes, mask, tables)
+        public TriggerQuery(Archetypes archetypes, Mask mask, List<Table> tables, Type systemType) : base(archetypes,
+            mask, tables)
         {
             _systemType = systemType;
         }
@@ -80,7 +81,7 @@ namespace RelEcs
     }
 
     public class Query<C> : Query
-        where C : class
+        where C : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -93,11 +94,11 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public C Get(Entity entity)
+        public ref C Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storage = (C[])Storages[meta.TableId][0];
-            return storage[meta.Row];
+            return ref storage[meta.Row];
         }
 
         public Enumerator<C> GetEnumerator()
@@ -107,8 +108,8 @@ namespace RelEcs
     }
 
     public class Query<C1, C2> : Query
-        where C1 : class
-        where C2 : class
+        where C1 : struct
+        where C2 : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -125,13 +126,13 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public (C1, C2) Get(Entity entity)
+        public RefValueTuple<C1, C2> Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storages = Storages[meta.TableId];
             var storage1 = (C1[])storages[0];
             var storage2 = (C2[])storages[1];
-            return (storage1[meta.Row], storage2[meta.Row]);
+            return new RefValueTuple<C1, C2>(ref storage1[meta.Row], ref storage2[meta.Row]);
         }
 
         public Enumerator<C1, C2> GetEnumerator()
@@ -141,9 +142,9 @@ namespace RelEcs
     }
 
     public class Query<C1, C2, C3> : Query
-        where C1 : class
-        where C2 : class
-        where C3 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -161,14 +162,15 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public (C1, C2, C3) Get(Entity entity)
+        public RefValueTuple<C1, C2, C3> Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storages = Storages[meta.TableId];
             var storage1 = (C1[])storages[0];
             var storage2 = (C2[])storages[1];
             var storage3 = (C3[])storages[2];
-            return (storage1[meta.Row], storage2[meta.Row], storage3[meta.Row]);
+            return new RefValueTuple<C1, C2, C3>(ref storage1[meta.Row], ref storage2[meta.Row],
+                ref storage3[meta.Row]);
         }
 
         public Enumerator<C1, C2, C3> GetEnumerator()
@@ -178,10 +180,10 @@ namespace RelEcs
     }
 
     public class Query<C1, C2, C3, C4> : Query
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -200,7 +202,7 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public (C1, C2, C3, C4) Get(Entity entity)
+        public RefValueTuple<C1, C2, C3, C4> Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storages = Storages[meta.TableId];
@@ -208,7 +210,8 @@ namespace RelEcs
             var storage2 = (C2[])storages[1];
             var storage3 = (C3[])storages[2];
             var storage4 = (C4[])storages[3];
-            return (storage1[meta.Row], storage2[meta.Row], storage3[meta.Row], storage4[meta.Row]);
+            return new RefValueTuple<C1, C2, C3, C4>(ref storage1[meta.Row], ref storage2[meta.Row],
+                ref storage3[meta.Row], ref storage4[meta.Row]);
         }
 
         public Enumerator<C1, C2, C3, C4> GetEnumerator()
@@ -218,11 +221,11 @@ namespace RelEcs
     }
 
     public class Query<C1, C2, C3, C4, C5> : Query
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -242,7 +245,7 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public (C1, C2, C3, C4, C5) Get(Entity entity)
+        public RefValueTuple<C1, C2, C3, C4, C5> Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storages = Storages[meta.TableId];
@@ -251,7 +254,8 @@ namespace RelEcs
             var storage3 = (C3[])storages[2];
             var storage4 = (C4[])storages[3];
             var storage5 = (C5[])storages[4];
-            return (storage1[meta.Row], storage2[meta.Row], storage3[meta.Row], storage4[meta.Row], storage5[meta.Row]);
+            return new RefValueTuple<C1, C2, C3, C4, C5>(ref storage1[meta.Row], ref storage2[meta.Row],
+                ref storage3[meta.Row], ref storage4[meta.Row], ref storage5[meta.Row]);
         }
 
         public Enumerator<C1, C2, C3, C4, C5> GetEnumerator()
@@ -261,12 +265,12 @@ namespace RelEcs
     }
 
     public class Query<C1, C2, C3, C4, C5, C6> : Query
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
-        where C6 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
+        where C6 : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -287,7 +291,7 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public (C1, C2, C3, C4, C5, C6) Get(Entity entity)
+        public RefValueTuple<C1, C2, C3, C4, C5, C6> Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storages = Storages[meta.TableId];
@@ -297,8 +301,9 @@ namespace RelEcs
             var storage4 = (C4[])storages[3];
             var storage5 = (C5[])storages[4];
             var storage6 = (C6[])storages[5];
-            return (storage1[meta.Row], storage2[meta.Row], storage3[meta.Row], storage4[meta.Row], storage5[meta.Row],
-                storage6[meta.Row]);
+            return new RefValueTuple<C1, C2, C3, C4, C5, C6>(ref storage1[meta.Row], ref storage2[meta.Row],
+                ref storage3[meta.Row], ref storage4[meta.Row], ref storage5[meta.Row],
+                ref storage6[meta.Row]);
         }
 
         public Enumerator<C1, C2, C3, C4, C5, C6> GetEnumerator()
@@ -308,13 +313,13 @@ namespace RelEcs
     }
 
     public class Query<C1, C2, C3, C4, C5, C6, C7> : Query
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
-        where C6 : class
-        where C7 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
+        where C6 : struct
+        where C7 : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -336,7 +341,7 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public (C1, C2, C3, C4, C5, C6, C7) Get(Entity entity)
+        public RefValueTuple<C1, C2, C3, C4, C5, C6, C7> Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storages = Storages[meta.TableId];
@@ -347,8 +352,9 @@ namespace RelEcs
             var storage5 = (C5[])storages[4];
             var storage6 = (C6[])storages[5];
             var storage7 = (C7[])storages[6];
-            return (storage1[meta.Row], storage2[meta.Row], storage3[meta.Row], storage4[meta.Row], storage5[meta.Row],
-                storage6[meta.Row], storage7[meta.Row]);
+            return new RefValueTuple<C1, C2, C3, C4, C5, C6, C7>(ref storage1[meta.Row], ref storage2[meta.Row],
+                ref storage3[meta.Row], ref storage4[meta.Row], ref storage5[meta.Row],
+                ref storage6[meta.Row], ref storage7[meta.Row]);
         }
 
         public Enumerator<C1, C2, C3, C4, C5, C6, C7> GetEnumerator()
@@ -358,14 +364,14 @@ namespace RelEcs
     }
 
     public class Query<C1, C2, C3, C4, C5, C6, C7, C8> : Query
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
-        where C6 : class
-        where C7 : class
-        where C8 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
+        where C6 : struct
+        where C7 : struct
+        where C8 : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -388,7 +394,7 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public (C1, C2, C3, C4, C5, C6, C7, C8) Get(Entity entity)
+        public RefValueTuple<C1, C2, C3, C4, C5, C6, C7, C8> Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storages = Storages[meta.TableId];
@@ -400,8 +406,9 @@ namespace RelEcs
             var storage6 = (C6[])storages[5];
             var storage7 = (C7[])storages[6];
             var storage8 = (C8[])storages[7];
-            return (storage1[meta.Row], storage2[meta.Row], storage3[meta.Row], storage4[meta.Row], storage5[meta.Row],
-                storage6[meta.Row], storage7[meta.Row], storage8[meta.Row]);
+            return new RefValueTuple<C1, C2, C3, C4, C5, C6, C7, C8>(ref storage1[meta.Row], ref storage2[meta.Row],
+                ref storage3[meta.Row], ref storage4[meta.Row], ref storage5[meta.Row],
+                ref storage6[meta.Row], ref storage7[meta.Row], ref storage8[meta.Row]);
         }
 
         public Enumerator<C1, C2, C3, C4, C5, C6, C7, C8> GetEnumerator()
@@ -411,15 +418,15 @@ namespace RelEcs
     }
 
     public class Query<C1, C2, C3, C4, C5, C6, C7, C8, C9> : Query
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
-        where C6 : class
-        where C7 : class
-        where C8 : class
-        where C9 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
+        where C6 : struct
+        where C7 : struct
+        where C8 : struct
+        where C9 : struct
     {
         public Query(Archetypes archetypes, Mask mask, List<Table> tables) : base(archetypes, mask, tables)
         {
@@ -443,7 +450,7 @@ namespace RelEcs
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public (C1, C2, C3, C4, C5, C6, C7, C8, C9) Get(Entity entity)
+        public RefValueTuple<C1, C2, C3, C4, C5, C6, C7, C8, C9> Get(Entity entity)
         {
             var meta = Archetypes.GetEntityMeta(entity.Identity);
             var storages = Storages[meta.TableId];
@@ -456,8 +463,9 @@ namespace RelEcs
             var storage7 = (C7[])storages[6];
             var storage8 = (C8[])storages[7];
             var storage9 = (C9[])storages[8];
-            return (storage1[meta.Row], storage2[meta.Row], storage3[meta.Row], storage4[meta.Row], storage5[meta.Row],
-                storage6[meta.Row], storage7[meta.Row], storage8[meta.Row], storage9[meta.Row]);
+            return new RefValueTuple<C1, C2, C3, C4, C5, C6, C7, C8, C9>(ref storage1[meta.Row], ref storage2[meta.Row],
+                ref storage3[meta.Row], ref storage4[meta.Row], ref storage5[meta.Row],
+                ref storage6[meta.Row], ref storage7[meta.Row], ref storage8[meta.Row], ref storage9[meta.Row]);
         }
 
         public Enumerator<C1, C2, C3, C4, C5, C6, C7, C8, C9> GetEnumerator()
@@ -669,10 +677,10 @@ namespace RelEcs
             _storage = Tables[TableIndex].GetStorage<C>(Identity.None);
         }
 
-        public C Current
+        public Ref<C> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _storage[EntityIndex];
+            get => new(ref _storage[EntityIndex]);
         }
     }
 
@@ -694,10 +702,10 @@ namespace RelEcs
             _storage2 = Tables[TableIndex].GetStorage<C2>(Identity.None);
         }
 
-        public (C1, C2) Current
+        public RefValueTuple<C1, C2> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (_storage1[EntityIndex], _storage2[EntityIndex]);
+            get => new(ref _storage1[EntityIndex], ref _storage2[EntityIndex]);
         }
     }
 
@@ -721,10 +729,10 @@ namespace RelEcs
             _storage3 = Tables[TableIndex].GetStorage<C3>(Identity.None);
         }
 
-        public (C1, C2, C3) Current
+        public RefValueTuple<C1, C2, C3> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (_storage1[EntityIndex], _storage2[EntityIndex], _storage3[EntityIndex]);
+            get => new(ref _storage1[EntityIndex], ref _storage2[EntityIndex], ref _storage3[EntityIndex]);
         }
     }
 
@@ -750,10 +758,11 @@ namespace RelEcs
             _storage4 = Tables[TableIndex].GetStorage<C4>(Identity.None);
         }
 
-        public (C1, C2, C3, C4) Current
+        public RefValueTuple<C1, C2, C3, C4> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (_storage1[EntityIndex], _storage2[EntityIndex], _storage3[EntityIndex], _storage4[EntityIndex]);
+            get => new(ref _storage1[EntityIndex], ref _storage2[EntityIndex], ref _storage3[EntityIndex],
+                ref _storage4[EntityIndex]);
         }
     }
 
@@ -781,11 +790,11 @@ namespace RelEcs
             _storage5 = Tables[TableIndex].GetStorage<C5>(Identity.None);
         }
 
-        public (C1, C2, C3, C4, C5) Current
+        public RefValueTuple<C1, C2, C3, C4, C5> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (_storage1[EntityIndex], _storage2[EntityIndex], _storage3[EntityIndex], _storage4[EntityIndex],
-                _storage5[EntityIndex]);
+            get => new(ref _storage1[EntityIndex], ref _storage2[EntityIndex], ref _storage3[EntityIndex],
+                ref _storage4[EntityIndex], ref _storage5[EntityIndex]);
         }
     }
 
@@ -815,11 +824,11 @@ namespace RelEcs
             _storage6 = Tables[TableIndex].GetStorage<C6>(Identity.None);
         }
 
-        public (C1, C2, C3, C4, C5, C6) Current
+        public RefValueTuple<C1, C2, C3, C4, C5, C6> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (_storage1[EntityIndex], _storage2[EntityIndex], _storage3[EntityIndex], _storage4[EntityIndex],
-                _storage5[EntityIndex], _storage6[EntityIndex]);
+            get => new(ref _storage1[EntityIndex], ref _storage2[EntityIndex], ref _storage3[EntityIndex],
+                ref _storage4[EntityIndex], ref _storage5[EntityIndex], ref _storage6[EntityIndex]);
         }
     }
 
@@ -851,11 +860,12 @@ namespace RelEcs
             _storage7 = Tables[TableIndex].GetStorage<C7>(Identity.None);
         }
 
-        public (C1, C2, C3, C4, C5, C6, C7) Current
+        public RefValueTuple<C1, C2, C3, C4, C5, C6, C7> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (_storage1[EntityIndex], _storage2[EntityIndex], _storage3[EntityIndex], _storage4[EntityIndex],
-                _storage5[EntityIndex], _storage6[EntityIndex], _storage7[EntityIndex]);
+            get => new(ref _storage1[EntityIndex], ref _storage2[EntityIndex], ref _storage3[EntityIndex],
+                ref _storage4[EntityIndex], ref _storage5[EntityIndex], ref _storage6[EntityIndex],
+                ref _storage7[EntityIndex]);
         }
     }
 
@@ -889,11 +899,12 @@ namespace RelEcs
             _storage8 = Tables[TableIndex].GetStorage<C8>(Identity.None);
         }
 
-        public (C1, C2, C3, C4, C5, C6, C7, C8) Current
+        public RefValueTuple<C1, C2, C3, C4, C5, C6, C7, C8> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (_storage1[EntityIndex], _storage2[EntityIndex], _storage3[EntityIndex], _storage4[EntityIndex],
-                _storage5[EntityIndex], _storage6[EntityIndex], _storage7[EntityIndex], _storage8[EntityIndex]);
+            get => new(ref _storage1[EntityIndex], ref _storage2[EntityIndex], ref _storage3[EntityIndex],
+                ref _storage4[EntityIndex], ref _storage5[EntityIndex], ref _storage6[EntityIndex],
+                ref _storage7[EntityIndex], ref _storage8[EntityIndex]);
         }
     }
 
@@ -929,12 +940,12 @@ namespace RelEcs
             _storage9 = Tables[TableIndex].GetStorage<C9>(Identity.None);
         }
 
-        public (C1, C2, C3, C4, C5, C6, C7, C8, C9) Current
+        public RefValueTuple<C1, C2, C3, C4, C5, C6, C7, C8, C9> Current
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (_storage1[EntityIndex], _storage2[EntityIndex], _storage3[EntityIndex], _storage4[EntityIndex],
-                _storage5[EntityIndex], _storage6[EntityIndex], _storage7[EntityIndex], _storage8[EntityIndex],
-                _storage9[EntityIndex]);
+            get => new(ref _storage1[EntityIndex], ref _storage2[EntityIndex], ref _storage3[EntityIndex],
+                ref _storage4[EntityIndex], ref _storage5[EntityIndex], ref _storage6[EntityIndex],
+                ref _storage7[EntityIndex], ref _storage8[EntityIndex], ref _storage9[EntityIndex]);
         }
     }
 }

--- a/src/QueryBuilder.cs
+++ b/src/QueryBuilder.cs
@@ -19,7 +19,7 @@ namespace RelEcs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public QueryBuilder Has<T>(Entity target = default)
         {
-            var typeIndex = StorageType.Create<T>(target?.Identity ?? Identity.None);
+            var typeIndex = StorageType.Create<T>(target.Identity);
             Mask.Has(typeIndex);
             return this;
         }
@@ -36,7 +36,7 @@ namespace RelEcs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public QueryBuilder Not<T>(Entity target = default)
         {
-            var typeIndex = StorageType.Create<T>(target?.Identity ?? Identity.None);
+            var typeIndex = StorageType.Create<T>(target.Identity);
             Mask.Not(typeIndex);
             return this;
         }
@@ -53,7 +53,7 @@ namespace RelEcs
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public QueryBuilder Any<T>(Entity target = default)
         {
-            var typeIndex = StorageType.Create<T>(target?.Identity ?? Identity.None);
+            var typeIndex = StorageType.Create<T>(target.Identity);
             Mask.Any(typeIndex);
             return this;
         }
@@ -69,7 +69,7 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C> : QueryBuilder
-        where C : class
+        where C : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C>(archetypes, mask, matchingTables);
@@ -124,8 +124,8 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C1, C2> : QueryBuilder
-        where C1 : class
-        where C2 : class
+        where C1 : struct
+        where C2 : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C1, C2>(archetypes, mask, matchingTables);
@@ -180,9 +180,9 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C1, C2, C3> : QueryBuilder
-        where C1 : class
-        where C2 : class
-        where C3 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C1, C2, C3>(archetypes, mask, matchingTables);
@@ -237,10 +237,10 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C1, C2, C3, C4> : QueryBuilder
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C1, C2, C3, C4>(archetypes, mask, matchingTables);
@@ -295,11 +295,11 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C1, C2, C3, C4, C5> : QueryBuilder
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C1, C2, C3, C4, C5>(archetypes, mask, matchingTables);
@@ -354,12 +354,12 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C1, C2, C3, C4, C5, C6> : QueryBuilder
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
-        where C6 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
+        where C6 : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C1, C2, C3, C4, C5, C6>(archetypes, mask, matchingTables);
@@ -414,13 +414,13 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C1, C2, C3, C4, C5, C6, C7> : QueryBuilder
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
-        where C6 : class
-        where C7 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
+        where C6 : struct
+        where C7 : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C1, C2, C3, C4, C5, C6, C7>(archetypes, mask, matchingTables);
@@ -475,14 +475,14 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C1, C2, C3, C4, C5, C6, C7, C8> : QueryBuilder
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
-        where C6 : class
-        where C7 : class
-        where C8 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
+        where C6 : struct
+        where C7 : struct
+        where C8 : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C1, C2, C3, C4, C5, C6, C7, C8>(archetypes, mask, matchingTables);
@@ -537,15 +537,15 @@ namespace RelEcs
     }
 
     public sealed class QueryBuilder<C1, C2, C3, C4, C5, C6, C7, C8, C9> : QueryBuilder
-        where C1 : class
-        where C2 : class
-        where C3 : class
-        where C4 : class
-        where C5 : class
-        where C6 : class
-        where C7 : class
-        where C8 : class
-        where C9 : class
+        where C1 : struct
+        where C2 : struct
+        where C3 : struct
+        where C4 : struct
+        where C5 : struct
+        where C6 : struct
+        where C7 : struct
+        where C8 : struct
+        where C9 : struct
     {
         static readonly Func<Archetypes, Mask, List<Table>, Query> CreateQuery =
             (archetypes, mask, matchingTables) => new Query<C1, C2, C3, C4, C5, C6, C7, C8, C9>(archetypes, mask, matchingTables);

--- a/src/RefValueTuple.cs
+++ b/src/RefValueTuple.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace RelEcs;
+
+public readonly ref struct Ref<T>
+{
+    readonly Span<T> _span;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Ref(ref T r)
+    {
+        _span = MemoryMarshal.CreateSpan(ref r, 1);
+    }
+
+    public ref T Value
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref MemoryMarshal.GetReference(_span);
+    }
+}
+
+// TODO: Change Ref<T> to this when NET7 hits the fan for great perf boost
+// public readonly ref struct Ref<T>
+// {
+//     public readonly ref T Value;
+//
+//     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//     public Ref(ref T r)
+//     {
+//         Value = ref r;
+//     }
+// }
+
+public ref struct RefValueTuple<T1, T2>
+{
+    public Ref<T1> Item1;
+    public Ref<T2> Item2;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RefValueTuple(ref T1 item1, ref T2 item2)
+    {
+        Item1 = new Ref<T1>(ref item1);
+        Item2 = new Ref<T2>(ref item2);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deconstruct(out Ref<T1> item1, out Ref<T2> item2)
+    {
+        item1 = Item1;
+        item2 = Item2;
+    }
+}
+
+public ref struct RefValueTuple<T1, T2, T3>
+{
+    public Ref<T1> Item1;
+    public Ref<T2> Item2;
+    public Ref<T3> Item3;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RefValueTuple(ref T1 item1, ref T2 item2, ref T3 item3)
+    {
+        Item1 = new Ref<T1>(ref item1);
+        Item2 = new Ref<T2>(ref item2);
+        Item3 = new Ref<T3>(ref item3);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deconstruct(out Ref<T1> item1, out Ref<T2> item2, out Ref<T3> item3)
+    {
+        item1 = Item1;
+        item2 = Item2;
+        item3 = Item3;
+    }
+}
+
+public ref struct RefValueTuple<T1, T2, T3, T4>
+{
+    public Ref<T1> Item1;
+    public Ref<T2> Item2;
+    public Ref<T3> Item3;
+    public Ref<T4> Item4;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RefValueTuple(ref T1 item1, ref T2 item2, ref T3 item3, ref T4 item4)
+    {
+        Item1 = new Ref<T1>(ref item1);
+        Item2 = new Ref<T2>(ref item2);
+        Item3 = new Ref<T3>(ref item3);
+        Item4 = new Ref<T4>(ref item4);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deconstruct(out Ref<T1> item1, out Ref<T2> item2, out Ref<T3> item3, out Ref<T4> item4)
+    {
+        item1 = Item1;
+        item2 = Item2;
+        item3 = Item3;
+        item4 = Item4;
+    }
+}
+
+public ref struct RefValueTuple<T1, T2, T3, T4, T5>
+{
+    public Ref<T1> Item1;
+    public Ref<T2> Item2;
+    public Ref<T3> Item3;
+    public Ref<T4> Item4;
+    public Ref<T5> Item5;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RefValueTuple(ref T1 item1, ref T2 item2, ref T3 item3, ref T4 item4, ref T5 item5)
+    {
+        Item1 = new Ref<T1>(ref item1);
+        Item2 = new Ref<T2>(ref item2);
+        Item3 = new Ref<T3>(ref item3);
+        Item4 = new Ref<T4>(ref item4);
+        Item5 = new Ref<T5>(ref item5);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deconstruct(out Ref<T1> item1, out Ref<T2> item2, out Ref<T3> item3, out Ref<T4> item4,
+        out Ref<T5> item5)
+    {
+        item1 = Item1;
+        item2 = Item2;
+        item3 = Item3;
+        item4 = Item4;
+        item5 = Item5;
+    }
+}
+
+public ref struct RefValueTuple<T1, T2, T3, T4, T5, T6>
+{
+    public Ref<T1> Item1;
+    public Ref<T2> Item2;
+    public Ref<T3> Item3;
+    public Ref<T4> Item4;
+    public Ref<T5> Item5;
+    public Ref<T6> Item6;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RefValueTuple(ref T1 item1, ref T2 item2, ref T3 item3, ref T4 item4, ref T5 item5, ref T6 item6)
+    {
+        Item1 = new Ref<T1>(ref item1);
+        Item2 = new Ref<T2>(ref item2);
+        Item3 = new Ref<T3>(ref item3);
+        Item4 = new Ref<T4>(ref item4);
+        Item5 = new Ref<T5>(ref item5);
+        Item6 = new Ref<T6>(ref item6);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deconstruct(out Ref<T1> item1, out Ref<T2> item2, out Ref<T3> item3, out Ref<T4> item4,
+        out Ref<T5> item5, out Ref<T6> item6)
+    {
+        item1 = Item1;
+        item2 = Item2;
+        item3 = Item3;
+        item4 = Item4;
+        item5 = Item5;
+        item6 = Item6;
+    }
+}
+
+public ref struct RefValueTuple<T1, T2, T3, T4, T5, T6, T7>
+{
+    public Ref<T1> Item1;
+    public Ref<T2> Item2;
+    public Ref<T3> Item3;
+    public Ref<T4> Item4;
+    public Ref<T5> Item5;
+    public Ref<T6> Item6;
+    public Ref<T7> Item7;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RefValueTuple(ref T1 item1, ref T2 item2, ref T3 item3, ref T4 item4, ref T5 item5, ref T6 item6,
+        ref T7 item7)
+    {
+        Item1 = new Ref<T1>(ref item1);
+        Item2 = new Ref<T2>(ref item2);
+        Item3 = new Ref<T3>(ref item3);
+        Item4 = new Ref<T4>(ref item4);
+        Item5 = new Ref<T5>(ref item5);
+        Item6 = new Ref<T6>(ref item6);
+        Item7 = new Ref<T7>(ref item7);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deconstruct(out Ref<T1> item1, out Ref<T2> item2, out Ref<T3> item3, out Ref<T4> item4,
+        out Ref<T5> item5, out Ref<T6> item6, out Ref<T7> item7)
+    {
+        item1 = Item1;
+        item2 = Item2;
+        item3 = Item3;
+        item4 = Item4;
+        item5 = Item5;
+        item6 = Item6;
+        item7 = Item7;
+    }
+}
+
+public ref struct RefValueTuple<T1, T2, T3, T4, T5, T6, T7, T8>
+{
+    public Ref<T1> Item1;
+    public Ref<T2> Item2;
+    public Ref<T3> Item3;
+    public Ref<T4> Item4;
+    public Ref<T5> Item5;
+    public Ref<T6> Item6;
+    public Ref<T7> Item7;
+    public Ref<T8> Item8;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RefValueTuple(ref T1 item1, ref T2 item2, ref T3 item3, ref T4 item4, ref T5 item5, ref T6 item6,
+        ref T7 item7, ref T8 item8)
+    {
+        Item1 = new Ref<T1>(ref item1);
+        Item2 = new Ref<T2>(ref item2);
+        Item3 = new Ref<T3>(ref item3);
+        Item4 = new Ref<T4>(ref item4);
+        Item5 = new Ref<T5>(ref item5);
+        Item6 = new Ref<T6>(ref item6);
+        Item7 = new Ref<T7>(ref item7);
+        Item8 = new Ref<T8>(ref item8);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deconstruct(out Ref<T1> item1, out Ref<T2> item2, out Ref<T3> item3, out Ref<T4> item4,
+        out Ref<T5> item5, out Ref<T6> item6, out Ref<T7> item7, out Ref<T8> item8)
+    {
+        item1 = Item1;
+        item2 = Item2;
+        item3 = Item3;
+        item4 = Item4;
+        item5 = Item5;
+        item6 = Item6;
+        item7 = Item7;
+        item8 = Item8;
+    }
+}
+
+public ref struct RefValueTuple<T1, T2, T3, T4, T5, T6, T7, T8, T9>
+{
+    public Ref<T1> Item1;
+    public Ref<T2> Item2;
+    public Ref<T3> Item3;
+    public Ref<T4> Item4;
+    public Ref<T5> Item5;
+    public Ref<T6> Item6;
+    public Ref<T7> Item7;
+    public Ref<T8> Item8;
+    public Ref<T9> Item9;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RefValueTuple(ref T1 item1, ref T2 item2, ref T3 item3, ref T4 item4, ref T5 item5, ref T6 item6,
+        ref T7 item7, ref T8 item8, ref T9 item9)
+    {
+        Item1 = new Ref<T1>(ref item1);
+        Item2 = new Ref<T2>(ref item2);
+        Item3 = new Ref<T3>(ref item3);
+        Item4 = new Ref<T4>(ref item4);
+        Item5 = new Ref<T5>(ref item5);
+        Item6 = new Ref<T6>(ref item6);
+        Item7 = new Ref<T7>(ref item7);
+        Item8 = new Ref<T8>(ref item8);
+        Item9 = new Ref<T9>(ref item9);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Deconstruct(out Ref<T1> item1, out Ref<T2> item2, out Ref<T3> item3, out Ref<T4> item4,
+        out Ref<T5> item5, out Ref<T6> item6, out Ref<T7> item7, out Ref<T8> item8, out Ref<T9> item9)
+    {
+        item1 = Item1;
+        item2 = Item2;
+        item3 = Item3;
+        item4 = Item4;
+        item5 = Item5;
+        item6 = Item6;
+        item7 = Item7;
+        item8 = Item8;
+        item9 = Item9;
+    }
+}

--- a/src/Trigger.cs
+++ b/src/Trigger.cs
@@ -8,13 +8,13 @@ namespace RelEcs
         internal T Value;
     }
 
-    internal class SystemList
+    internal struct SystemList
     {
         public readonly List<Type> List;
         public SystemList() => List = ListPool<Type>.Get();
     }
 
-    internal class LifeTime
+    internal struct LifeTime
     {
         public int Value;
     }
@@ -28,12 +28,12 @@ namespace RelEcs
             var query = World.Query<Entity, SystemList, LifeTime>().Build();
             foreach (var (entity, systemList, lifeTime) in query)
             {
-                lifeTime.Value++;
-
-                if (lifeTime.Value < 2) return;
-
-                ListPool<Type>.Add(systemList.List);
-                World.Despawn(entity);
+                lifeTime.Value.Value++;
+                
+                if (lifeTime.Value.Value < 2) return;
+                
+                ListPool<Type>.Add(systemList.Value.List);
+                World.Despawn(entity.Value);
             }
         }
     }


### PR DESCRIPTION
This PR changes components to be structs again.
I found a way to keep the  `foreach(var (a, b, c) in query)` syntax even when using structs.
though, now, instead of directly being of the respective types, `a`, `b` and `c` would be of the types `Ref<A>`, `Ref<B>` and `Ref<C>` respectively.
That means `.Value` is required to access the actual component struct.
```csharp
var query = world.Query<Position, Velocity>().Build();
foreach(var (pos, vel) in query)
{
    pos.Value.X += vel.Value.X;
    pos.Value.Y += vel.Value.Y;
}
```
It's not ideal, but a fair trade between ergonomics and performance. Using structs nets us significant performance improvements down the line, due to better cache line optimisations.